### PR TITLE
Validate add comments

### DIFF
--- a/src/constraint/CommentValidation.php
+++ b/src/constraint/CommentValidation.php
@@ -23,11 +23,8 @@ class CommentValidation extends Validation
 
     private function checkField($name, $value)
     {
-        if($name === 'pseudo') {
-            $error = $this->checkPseudo($name, $value);
-            $this->addError($name, $error);
-        }
-        elseif ($name === 'content') {
+       
+        if ($name === 'content') {
             $error = $this->checkContent($name, $value);
             $this->addError($name, $error);
         }
@@ -38,19 +35,6 @@ class CommentValidation extends Validation
             $this->errors += [
                 $name => $error
             ];
-        }
-    }
-
-    private function checkPseudo($name, $value)
-    {
-        if($this->constraint->notBlank($name, $value)) {
-            return $this->constraint->notBlank('pseudo', $value);
-        }
-        if($this->constraint->minLength($name, $value, 2)) {
-            return $this->constraint->minLength('pseudo', $value, 2);
-        }
-        if($this->constraint->maxLength($name, $value, 255)) {
-            return $this->constraint->maxLength('pseudo', $value, 255);
         }
     }
 

--- a/src/controller/BackController.php
+++ b/src/controller/BackController.php
@@ -36,7 +36,10 @@ class BackController extends Controller
         if($post->get('submit')){
             $this->articleDAO->articleEditAdmin($post, $articleId);
             $this->session->set('articlesListAdmin', 'Article modifié !');
-            return header('Location:index.php?route=articlesListAdmin');
+            $articles = $this->articleDAO->getArticles();
+            return $this->view->render('articlesListAdmin', [
+                'articles' => $articles
+            ]);
         }    
         return $this->view->render('edit_ArticleAdmin', [
             'article' => $article

--- a/src/controller/FrontController.php
+++ b/src/controller/FrontController.php
@@ -3,7 +3,7 @@
 namespace App\src\controller;
 
 use App\config\Parameter;
-
+use Exception;
 class FrontController extends Controller
 {
     
@@ -41,8 +41,9 @@ class FrontController extends Controller
             $errors = $this->validation->validate($post, 'Comment');
             if(!$errors) {
                 $this->commentDAO->addComment($post, $articleId);
-                $this->session->set('add_comment', 'Commentaire ajouté');
+                $this->session->set('add_comment', 'Commentaire ajouté en attente de validation !');
             }
+            
             $article = $this->articleDAO->getArticle($articleId);
             $comments = $this->commentDAO->getCommentsArticle($articleId);
             return $this->view->render('single', [

--- a/templates/single.php
+++ b/templates/single.php
@@ -37,6 +37,7 @@
             <input type="int" id="id_user" name="id_user"><br>
                 <div class='form-group '>
                     <textarea class="form-control" id="comment" name="content" placeholder="Votre texte"></textarea>
+                    <?= isset($errors['content']) ? $errors['content'] : ''; ?>
                 </div>
                 <div>
                     <input type="submit" class="btn btn-success mb-4" value="J'envoie mon commentaire !" id="submit" name="submit">


### PR DESCRIPTION
Validation commentaire ok :) En fait j'ai trouvé une soluce pour remplacer les header location : je remplace par des render quand je peux exemple je viens de corriger un header qui faisait une toute petite ligne de rien du tout et qui faisait râler Codacy ... 
j'ai remplacer par : 
$articles = $this->articleDAO->getArticles();
            return $this->view->render('articlesListAdmin', [
                'articles' => $articles
            ]); Qui me refait faire un tour dans le model avec une requete en plus, donc plus de code, plus de resources au niveau des appels... et CODACY EST CONTENT!!! il me passe au vert pfff mdrrr... alors qu'avec un petit header de rien du tout, je ne faisais pas 3 lignes de code, pas d'appel supplémentaire supplémentaire, vraiment étrange de Codacy...